### PR TITLE
add dummy comment delete function

### DIFF
--- a/src/components/DummyComment.jsx
+++ b/src/components/DummyComment.jsx
@@ -1,19 +1,19 @@
-export default function DummyComment({ comment }) {
-  const { userName, body, comment_id } = comment;
+export default function DummyComment({ comment, deleteDummy, index }) {
+  const { userName, body } = comment;
 
-  function handleClick_DeleteDummyComment() {
-    // trigger a re render of the dummyCommentsList
-    console.log("trying to delete the dummy comment");
-  }
+  //need to somehow pass in the comment_id from the new comment.
+  // will need get request to  server and refresh the comments?
+  //this comment_id will then be sent as a delete request to the server
+  //currently, deleting dummy_comment does not send any delete request to the server
 
   return (
     <section className="comment-card">
-      <h3>{userName} Dummy COMMETNT!!</h3>
+      <h3>{userName} This is a dummy comment, optimistic rendering</h3>
       <p className="body">{body}</p>
       <div>votes: 0</div>
       <div>Just now</div>
 
-      <button onClick={handleClick_DeleteDummyComment} type="button">
+      <button type="button" onClick={() => deleteDummy(index)}>
         Delete comment
       </button>
     </section>

--- a/src/components/User-Submit/NewCommentForm.jsx
+++ b/src/components/User-Submit/NewCommentForm.jsx
@@ -21,7 +21,17 @@ export default function NewCommentForm() {
     submitComment(article_id, newComment);
     setCommentBody("");
     setDummyCommentsList([newComment, ...dummyCommentsList]);
+
+    //when the submission is sent, it should refresh the comments on the page again
+    // getCommentsByArticleId(article_id).then((result) => {
+    //   setComments(result);
+    // });
   };
+
+  function handleDeleteDummy(comment_index) {
+    dummyCommentsList.splice(comment_index, 1);
+    setDummyCommentsList([...dummyCommentsList]);
+  }
 
   return (
     <section>
@@ -44,7 +54,12 @@ export default function NewCommentForm() {
       </form>
       <div>
         {dummyCommentsList.map((comment, index) => (
-          <DummyComment key={index} comment={comment} />
+          <DummyComment
+            key={index}
+            index={index}
+            comment={comment}
+            deleteDummy={handleDeleteDummy}
+          />
         ))}
       </div>
     </section>


### PR DESCRIPTION
User now has optimistic rendering of deleting their comment. 
However, the functionality is broken, as the dummy_comment delete function does not currently send a delete request to the API. This results in a false positive (user believes comment is deleted when it is not in fact deleted.) 
Don't have access to the variable comment_id which is required to send the correct delete request, until the page is refreshed with a new get request.

2 proposed methods to fix this:

1. Modify the API's back-end so it returns the comment_id of the submitted comment. This will provide an opportunity to include a delete request within the delete_dummy_comment function (preferred)
2. Avoid using optimistic rendering for the delete comment functionality.

